### PR TITLE
Meteor_Collision crash bug [FIX]

### DIFF
--- a/scripts/BaseLevel.gd
+++ b/scripts/BaseLevel.gd
@@ -150,7 +150,7 @@ func start_level() -> void:
 func lose_handler() -> void:
 	handle_overlay("lose")
 	Globals.level_running = false
-	for m in current_meteors:
+	for m in $Meteors.get_children():
 		m.queue_free()
 
 


### PR DESCRIPTION
loops through all current $Meteor children and queues them for deletion